### PR TITLE
sscopes: improve compatibility with the system gallery app

### DIFF
--- a/src/com/android/providers/media/MediaProvider.java
+++ b/src/com/android/providers/media/MediaProvider.java
@@ -7769,7 +7769,14 @@ public class MediaProvider extends ContentProvider {
                 // database updates for SystemGallery targeting R or above on R OS.
                 return false;
             }
-            return mCallingIdentity.get().shouldBypassDatabase(true /*isSystemGallery*/);
+            LocalCallingIdentity callingIdentity = mCallingIdentity.get();
+            boolean res = callingIdentity.shouldBypassDatabase(true /*isSystemGallery*/);
+
+            if (res && callingIdentity.getStorageScopes() != null) {
+                return false;
+            }
+
+            return res;
         }
         return false;
     }


### PR DESCRIPTION
To improve performance, system gallery app is allowed to bypass the database when it updates shared
storage state, which is incompatible with Storage Scopes (it relies on database for ownership-based
file visibility).
Disable this performance optimization when Storage Scopes is enabled.