### PR TITLE
require permission for access to /Alarms/, /Notifications/, /Ringtones/

### DIFF
--- a/StorageScopes.md
+++ b/StorageScopes.md
@@ -1,0 +1,70 @@
+For an introduction, read https://developer.android.com/training/data-storage#permissions and
+https://source.android.com/devices/storage/scoped
+
+The purpose of the Storage Scopes feature is to allow the user to configure which files a given
+app has access to.
+
+As a baseline, MediaProvider allows a modern app (targetSdk >= 29, unless legacy external storage
+is enabled for that app) to see all files that were created by it. No storage permission is needed
+for this type of access.
+
+When the Storage Scopes feature is enabled, modern external storage is enforced regardless of the
+targetSdk value, and the app assumes that it has all of storage permissions that were declared in its
+AndroidManifest (both runtime and app-op storage permission self-checks are spoofed for that app).
+Enabling the Storage Scopes feature is allowed only when the app isn't granted any storage permission.
+
+If the app expects to be granted the "All files access" permission (it has an explicit
+"All files access" permission declaration or would normally use legacy external storage and has
+declared the WRITE_EXTERNAL_STORAGE permission), then the write restrictions that are normally
+enforced for apps that don't have a storage permission are slightly relaxed:
+- app is allowed to create directories in any external storage directory (except Android/data
+and Android/obb). Normally, directory creation is allowed only inside the standard directories
+(Documents, Music, Pictures etc)
+- app is allowed to create files in any external storage directory (again, except Android/data and
+Android/obb). Normally, file creation is allowed only inside the standard directories and the file type
+is enforced (eg lyrics.txt file is not allowed to be created inside the Music directory)
+- app is allowed to remove empty top-level directories. Normally, removal is allowed only for
+non-top-level empty directories
+- app is allowed to rename files / directories in (and into) the root of external storage, but
+only if all affected files are writable by the app
+
+Optionally, the user can specify additional files and directories that the app can access (ie those
+that weren't created by the app itself). The standard SAF picker is used to select them, and the list
+of picked locations (scopes) is persisted via GrapheneOS-specific PackageManagerService extension
+(GosPackageState).
+
+Read-write access to user-picked scopes is granted only if the app declares the need for write
+storage access in its AndroidManifest, otherwise read-only access is granted.
+
+All of the above specified changes apply to both traditional file access APIs (POSIX, java.io.File etc)
+and MediaProvider APIs (query(), insert(), update(), delete() etc)
+
+# Changes to visibility of directory names
+Upstream MediaProvider allows apps that don't have any storage permission to read the list of
+all external storage directories via readdir(), java.io.File#list() etc.
+
+This metadata leak is addressed by returning only those directories for which at least one of the
+following conditions is true:
+- it has files that the app created
+- it has files / directories that are in the list of user-picked scopes
+- it's inside a user-picked directory
+
+Note that unlike all other changes described above, this change applies to all apps that don't have
+a storage permission, regardless of whether the Storage Scopes feature is enabled.
+This behavior of the upstream MediaProvider is undocumented, only a small number of apps (if any)
+will be negatively affected by this change.
+
+# Limitations
+- If the app is reinstalled, it will lose access to all files that it created previously. This doesn't
+affect user-picked directories / files.
+- Access to files that the app created inside external storage, but outside its private Android/data
+directory and outside user-picked directories is significantly slower than accessing files inside those
+directories. This affects apps that use shared external storage instead of their private Android/data
+or internal /data/data directories to store large number of files that they access frequently.
+As a workaround, if these files are inside an app-specific directory (they almost always are),
+this directory can be added to the list of user-picked directories.
+Note that this performance difference applies only to operations that involve paths (open(), stat(),
+getdents() etc). Operations on file descriptors (read(), write(), fstat(), lseek() etc) aren't affected.
+- A directory that is created outside the user-picked directories isn't visible in the directory
+listing until at least one file is created inside of it. This kind of directory is still visible
+via stat() (which is used by java.io.File#{exists(), isDirectory()} etc).

--- a/jni/MediaProviderWrapper.cpp
+++ b/jni/MediaProviderWrapper.cpp
@@ -126,7 +126,7 @@ bool isUidAllowedAccessToDataOrObbPathInternal(JNIEnv* env, jobject media_provid
 
 std::vector<std::shared_ptr<DirectoryEntry>> getFilesInDirectoryInternal(
         JNIEnv* env, jobject media_provider_object, jmethodID mid_get_files_in_dir, uid_t uid,
-        const string& path) {
+        const string& path, bool* skip_add_dirs) {
     std::vector<std::shared_ptr<DirectoryEntry>> directory_entries;
     ScopedLocalRef<jstring> j_path(env, env->NewStringUTF(path.c_str()));
 
@@ -155,6 +155,8 @@ std::vector<std::shared_ptr<DirectoryEntry>> getFilesInDirectoryInternal(
         }
     }
 
+    int de_type = DT_REG;
+
     for (int i = 0; i < de_count; i++) {
         ScopedLocalRef<jstring> j_d_name(env,
                                          (jstring)env->GetObjectArrayElement(files_list.get(), i));
@@ -166,7 +168,14 @@ std::vector<std::shared_ptr<DirectoryEntry>> getFilesInDirectoryInternal(
             directory_entries.push_back(std::make_shared<DirectoryEntry>("", EFAULT));
             break;
         }
-        directory_entries.push_back(std::make_shared<DirectoryEntry>(d_name.c_str(), DT_REG));
+
+        if (d_name.c_str()[0] == 0) { // see StorageScopesHooks#obtainDirContents
+            de_type = DT_DIR;
+            *skip_add_dirs = true;
+            continue;
+        }
+
+        directory_entries.push_back(std::make_shared<DirectoryEntry>(d_name.c_str(), de_type));
     }
     return directory_entries;
 }
@@ -380,7 +389,8 @@ std::vector<std::shared_ptr<DirectoryEntry>> MediaProviderWrapper::GetDirectoryE
     }
 
     JNIEnv* env = MaybeAttachCurrentThread();
-    res = getFilesInDirectoryInternal(env, media_provider_object_, mid_get_files_in_dir_, uid, path);
+    bool skip_add_dirs = false;
+    res = getFilesInDirectoryInternal(env, media_provider_object_, mid_get_files_in_dir_, uid, path, &skip_add_dirs);
 
     const int res_size = res.size();
     if (res_size && res[0]->d_name[0] == '/') {
@@ -389,7 +399,9 @@ std::vector<std::shared_ptr<DirectoryEntry>> MediaProviderWrapper::GetDirectoryE
         addDirectoryEntriesFromLowerFs(dirp, /* filter */ nullptr, &res);
     } else if (res_size == 0 || !res[0]->d_name.empty()) {
         // add directory names from lower file system.
-        addDirectoryEntriesFromLowerFs(dirp, /* filter */ &isDirectory, &res);
+        if (!skip_add_dirs) {
+            addDirectoryEntriesFromLowerFs(dirp, /* filter */ &isDirectory, &res);
+        }
     }
     return res;
 }

--- a/src/com/android/providers/media/MediaProvider.java
+++ b/src/com/android/providers/media/MediaProvider.java
@@ -6466,6 +6466,28 @@ public class MediaProvider extends ContentProvider {
 
                 return null;
             }
+            case StorageScope.MEDIA_PROVIDER_METHOD_MEDIA_ID_TO_FILE_PATH: {
+                // the only caller of this method is PermissionController
+                getContext().enforceCallingPermission(android.Manifest.permission.GRANT_RUNTIME_PERMISSIONS, null);
+
+                String mediaId = arg;
+                Uri uri = MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL, Long.parseLong(mediaId));
+
+                final CallingIdentity providerToken = clearCallingIdentity();
+                try {
+                    File f = queryForDataFile(uri, null);
+                    if (f != null) {
+                        var res = new Bundle();
+                        res.putString(mediaId, f.getAbsolutePath());
+                        return res;
+                    }
+                } catch (IOException e) {
+                    Log.d(TAG, "", e);
+                } finally {
+                    restoreCallingIdentity(providerToken);
+                }
+                return null;
+            }
             default:
                 throw new UnsupportedOperationException("Unsupported call: " + method);
         }

--- a/src/com/android/providers/media/MediaProvider.java
+++ b/src/com/android/providers/media/MediaProvider.java
@@ -5319,12 +5319,8 @@ public class MediaProvider extends ContentProvider {
                             FileColumns.MEDIA_TYPE_AUDIO);
                 }
                 if (!allowGlobal && !checkCallingPermissionAudio(forWrite, callingPackage)) {
-                    // Apps without Audio permission can only see their own
-                    // media, but we also let them see ringtone-style media to
-                    // support legacy use-cases.
-                    appendWhereStandalone(qb,
-                            DatabaseUtils.bindSelection(matchSharedPackagesClause
-                                    + " OR is_ringtone=1 OR is_alarm=1 OR is_notification=1"));
+                    // Apps without Audio permission can only see their own media
+                    appendWhereStandalone(qb, matchSharedPackagesClause);
                 }
                 appendWhereStandaloneFilter(qb, new String[] {
                         AudioColumns.ARTIST_KEY, AudioColumns.ALBUM_KEY, AudioColumns.TITLE_KEY

--- a/src/com/android/providers/media/PermissionActivity.java
+++ b/src/com/android/providers/media/PermissionActivity.java
@@ -214,7 +214,7 @@ public class PermissionActivity extends Activity {
                     getCallingPackage(), null /* attributionTag */, verb);
         }
 
-        if (!shouldShowActionDialog) {
+        if (!shouldShowActionDialog || StorageScopesHooks.shouldSkipConfirmationDialog(this, getCallingPackage(), uris)) {
             onPositiveAction(null, 0);
             return;
         }

--- a/src/com/android/providers/media/StorageScopesHooks.java
+++ b/src/com/android/providers/media/StorageScopesHooks.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright (C) 2022 GrapheneOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.providers.media;
+
+import android.annotation.Nullable;
+import android.app.StorageScope;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.pm.GosPackageState;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.ParcelFileDescriptor;
+import android.provider.MediaStore.MediaColumns;
+import android.text.TextUtils;
+import android.util.ArraySet;
+import android.util.Log;
+
+import com.android.providers.media.util.DatabaseUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.content.pm.GosPackageState.DFLAG_EXPECTS_ALL_FILES_ACCESS;
+import static android.content.pm.GosPackageState.DFLAG_EXPECTS_STORAGE_WRITE_ACCESS;
+import static android.content.pm.GosPackageState.FLAG_STORAGE_SCOPES_ENABLED;
+
+class StorageScopesHooks {
+
+    private static final String TAG = "StorageScopesHooks";
+
+    // Media#getFilesInDirectoryForFuse(String path, int uid),
+    // when the caller doesn't have any storage permission
+    static String[] obtainDirContents(MediaProvider mp, final String dirPath,
+                                      Uri volumeUri, final String dirRelativePath,
+                                      LocalCallingIdentity callingIdentity, ArrayList<String> fileNamesList)
+    {
+        /*
+        Upstream MediaProvider allows apps that don't have any storage permission to read the
+        list of all external storage directories.
+
+        Address this metadata leak by returning only those directories that either
+         - have files that the app created
+         - visible via StorageScopes
+         */
+
+        Bundle queryArgs = new Bundle(3);
+        //  ESCAPE '\\' is needed by DatabaseUtils.escapeForLike() below
+        final String selection = MediaColumns.DATA + " LIKE ? ESCAPE '\\' and " + MediaColumns.MIME_TYPE + " not like 'null'";
+
+        queryArgs.putString(ContentResolver.QUERY_ARG_SQL_SELECTION, selection);
+        queryArgs.putStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, new String[] { DatabaseUtils.escapeForLike(dirPath) + "/%" });
+        queryArgs.putString(ContentResolver.QUERY_ARG_SQL_GROUP_BY, MediaColumns.RELATIVE_PATH);
+
+        final String[] projection = { MediaColumns.RELATIVE_PATH };
+
+        final ArraySet<String> dirEntries;
+        final ArrayList<String> dirNamesList;
+
+        try (final Cursor cursor = mp.query(volumeUri, projection, queryArgs, null)) {
+            dirNamesList = new ArrayList<>(cursor.getCount() + StorageScope.maxArrayLength() + 1);
+
+            // needed to ensure uniqueness of all dir entries (both files and dirs)
+            dirEntries = new ArraySet<>(fileNamesList.size() + dirNamesList.size());
+            dirEntries.addAll(fileNamesList);
+
+            if (dirRelativePath.equals("/")) {
+                // "Android" dir should always be visible for compatibility
+                maybeAddDirEntry("Android", dirEntries, dirNamesList);
+            }
+
+            while (cursor.moveToNext()) {
+                String childRelativePath = cursor.getString(0);
+
+                String childDirName = maybeExtractChildDirNameFromRelativePaths(
+                        dirRelativePath, childRelativePath);
+
+                if (childDirName != null) {
+                    maybeAddDirEntry(childDirName, dirEntries, dirNamesList);
+                }
+            }
+        }
+
+        StorageScope[] scopes = callingIdentity.getStorageScopes();
+
+        if (scopes != null) {
+            for (StorageScope scope : scopes) {
+                maybeExtractChildNameFromStorageScope(dirPath, scope,
+                        dirEntries, dirNamesList, fileNamesList);
+            }
+        }
+
+        fileNamesList.ensureCapacity(1 + dirNamesList.size());
+
+        // separator between files and dirs
+        fileNamesList.add("");
+
+        fileNamesList.addAll(dirNamesList);
+
+        return fileNamesList.toArray(new String[0]);
+    }
+
+    // #shouldBypassFuseRestrictions(boolean forWrite, String filePath)
+    static boolean isAllowedPath(String filePath, LocalCallingIdentity callingIdentity, boolean forWrite) {
+        return isAllowedPath(callingIdentity.getStorageScopes(), filePath, forWrite);
+    }
+
+    private static boolean isAllowedPath(@Nullable StorageScope[] scopes, @Nullable String filePath, boolean forWrite) {
+        if (scopes == null || filePath == null) {
+            return false;
+        }
+
+        for (StorageScope scope : scopes) {
+            if (forWrite && !scope.isWritable()) {
+                continue;
+            }
+
+            String scopePath = scope.path;
+
+            if (scope.isDirectory()) {
+                if (filePath.startsWith(scopePath)) {
+                    int len = scopePath.length();
+                    if (filePath.length() == len) {
+                        // exact match
+                        return true;
+                    }
+                    if (filePath.charAt(len) == '/') {
+                        // filePath is a sub-path of scopePath
+                        return true;
+                    }
+                }
+            } else if (scope.isFile()) {
+                if (filePath.equals(scopePath)) {
+                    // in case a directory was created with the same name
+                    if (new File(filePath).isFile()) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+
+    /*
+    Allow to perform write operations that are normally allowed only if the app holds the
+    "All files access" permission, but only if these operations don't affect files that the app
+    doesn't have access to.
+
+    #isOpendirAllowedForFuse, #isDirectoryCreationOrDeletionAllowedForFuse: allow to create
+    top-level directories, allow to delete empty top-level directories
+
+    #ensureFileColumns, #insertFileIfNecessaryForFuse: allow to create files of any type in all
+    accessible directories
+
+    #renameForFuse: allow to rename files / directories in (and into) the root of external storage,
+    but only if all affected files are writable by the app
+     */
+    static boolean shouldRelaxWriteRestrictions(LocalCallingIdentity callingIdentity) {
+        GosPackageState ps = callingIdentity.getGosPackageState();
+        int requiredDflags = DFLAG_EXPECTS_ALL_FILES_ACCESS | DFLAG_EXPECTS_STORAGE_WRITE_ACCESS;
+        return ps != null
+                && ps.hasFlag(FLAG_STORAGE_SCOPES_ENABLED)
+                && (ps.derivedFlags & requiredDflags) == requiredDflags;
+    }
+
+    private static final ThreadLocal<Boolean> queryBuilderHookInhibited = new ThreadLocal<>();
+
+    static void inhibitQueryBuilderHook() {
+        queryBuilderHookInhibited.set(Boolean.TRUE);
+    }
+
+    static void uninhibitQueryBuilderHook() {
+        queryBuilderHookInhibited.set(Boolean.FALSE);
+    }
+
+    /*
+    An app that doesn't have a storage permission is allowed to see the files that it contributed
+    itself. MediaProvider implements this by recording the app's package name and matching against
+    it for later queries / updates / deletes. Note that the MediaProvider enforces permissions
+    per uid and thus matches against the list of all package names that share the given uid.
+    In vast majority of cases there is only one package name per uid.
+
+    This hook modifies the SQL clause that matches against the list of shared packages to also
+    include the list of app's StorageScopes.
+     */
+    // #getQueryBuilderInternal
+    static String maybeModifyMatchSharedPackagesClause(String orig, LocalCallingIdentity callingIdentity, boolean forWrite) {
+        StorageScope[] scopes = callingIdentity.getStorageScopes();
+        if (scopes == null) {
+            return orig;
+        }
+
+        if (queryBuilderHookInhibited.get() == Boolean.TRUE) {
+            return orig;
+        }
+
+        String fragment = sqlFragment(scopes, callingIdentity, forWrite);
+        if (TextUtils.isEmpty(fragment)) { // empty fragments are cached too
+            return orig;
+        }
+
+        StringBuilder sb = new StringBuilder(orig.length() + fragment.length() + 6);
+        sb.append('(');
+        sb.append(orig);
+        sb.append(" OR ");
+        sb.append(fragment);
+        sb.append(')');
+
+        return sb.toString();
+    }
+
+    // PermissionActivity, after shouldShowActionDialog() returns true
+    static boolean shouldSkipConfirmationDialog(Context context, String packageName, List<Uri> uris) {
+        if (uris.size() > 10) {
+            // checking each Uri is slow when there's too many of them
+            return false;
+        }
+
+        GosPackageState ps = GosPackageState.get(packageName);
+        if (ps == null) {
+            return false;
+        }
+
+        if (!(ps.hasDerivedFlag(GosPackageState.DFLAG_HAS_MANAGE_MEDIA_DECLARATION) && ps.hasFlag(FLAG_STORAGE_SCOPES_ENABLED))) {
+            return false;
+        }
+
+        StorageScope[] scopes = StorageScope.deserializeArray(ps);
+
+        String[] projection = { MediaColumns.DATA };
+        for (Uri uri : uris) {
+            try {
+                try (Cursor c = context.getContentResolver().query(uri, projection, null, null)) {
+                    if (c == null || !c.moveToFirst()) {
+                        return false;
+                    }
+
+                    if (!isAllowedPath(scopes, c.getString(0), true)) {
+                        return false;
+                    }
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "", e);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // #openFileAndEnforcePathPermissionsHelper
+    static boolean shouldBypassMediaLocationPermissionCheck(LocalCallingIdentity callingIdentity, File file) {
+        GosPackageState ps = callingIdentity.getGosPackageState();
+
+        if (ps == null || !ps.hasDerivedFlag(GosPackageState.DFLAG_HAS_ACCESS_MEDIA_LOCATION_DECLARATION)) {
+            return false;
+        }
+
+        // ACCESS_MEDIA_LOCATION permission is auto-granted on stock OS when READ_EXTERNAL_STORAGE or
+        // MANAGE_EXTERNAL_STORAGE are granted. Not spoofing it for StorageScopes paths would lead to
+        // SecurityExceptions in apps that use MediaStore#setRequireOriginal(uri)
+
+        return isAllowedPath(file.getAbsolutePath(), callingIdentity, false);
+    }
+
+    private static String sqlFragment(StorageScope[] scopes, LocalCallingIdentity callingIdentity, boolean forWrite) {
+        String cache = forWrite ? callingIdentity.storageScopesSqlFragmentForWrite : callingIdentity.storageScopesSqlFragment;
+        if (cache != null) {
+            return cache;
+        }
+
+        final int scopeCount = scopes.length;
+
+        if (scopeCount == 0) {
+            return null;
+        }
+
+        boolean atLeastOneReadOnly = false;
+
+        StorageScope[] dirs = null;
+        int dirCount = 0;
+        StorageScope[] files = null;
+        int fileCount = 0;
+
+        int sbCapacityEstimate = 0;
+
+        for (int scopeIdx = 0; scopeIdx < scopeCount; ++scopeIdx) {
+            StorageScope scope = scopes[scopeIdx];
+            if (!scope.isWritable()) {
+                atLeastOneReadOnly = true;
+
+                if (forWrite) {
+                    continue;
+                }
+            }
+
+            int pathLen = scope.path.length();
+
+            if (scope.isDirectory()) {
+                if (dirs == null) {
+                    dirs = new StorageScope[scopeCount - scopeIdx];
+                }
+                dirs[dirCount++] = scope;
+                sbCapacityEstimate += pathLen + 25;
+            } else if (scope.isFile()) {
+                if (files == null) {
+                    files = new StorageScope[scopeCount - scopeIdx];
+                }
+                files[fileCount++] = scope;
+                sbCapacityEstimate += pathLen + 10;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder(sbCapacityEstimate);
+
+        if (dirCount != 0) {
+            for (int dirIdx = 0; dirIdx < dirCount; ++dirIdx) {
+                if (dirIdx != 0) {
+                    sb.append(" OR ");
+                }
+                StorageScope dir = dirs[dirIdx];
+                String path = dir.path;
+
+                sb.append(MediaColumns.DATA + " LIKE '");
+
+                // unfortunately, binding arguments is unsupported by the SQLiteQueryBuilder
+
+                for (int i = 0, m = path.length(); i < m; ++i) {
+                    char c = path.charAt(i);
+                    switch (c) {
+                        case '%':
+                        case '_':
+                        case '\\':
+                            sb.append('\\');
+                            break;
+                        case '\'':
+                            sb.append('\'');
+                            break;
+                    }
+                    sb.append(c);
+                }
+                sb.append("/%' ESCAPE '\\'");
+            }
+        }
+
+        if (fileCount != 0) {
+            if (dirCount != 0) {
+                sb.append(" OR ");
+            }
+
+            sb.append(MediaColumns.DATA + " IN (");
+
+            for (int fileIdx = 0; fileIdx < fileCount; ++fileIdx) {
+                if (fileIdx != 0) {
+                    sb.append(',');
+                }
+
+                StorageScope file = files[fileIdx];
+
+                String path = file.path;
+
+                sb.append('\'');
+
+                for (int i = 0, m = path.length(); i < m; ++i) {
+                    char c = path.charAt(i);
+                    if (c == '\'') {
+                        // escape '
+                        sb.append('\'');
+                    }
+                    sb.append(c);
+                }
+
+                sb.append('\'');
+            }
+
+            sb.append(')');
+        }
+
+        String res = sb.toString();
+
+        if (forWrite) {
+            callingIdentity.storageScopesSqlFragmentForWrite = res;
+            if (!atLeastOneReadOnly) {
+                callingIdentity.storageScopesSqlFragment = res;
+            }
+        } else {
+            callingIdentity.storageScopesSqlFragment = res;
+            if (!atLeastOneReadOnly) {
+                callingIdentity.storageScopesSqlFragmentForWrite = res;
+            }
+        }
+        return res;
+    }
+
+    // MediaProvider doesn't enforce validity of file paths in all cases, which means that the
+    // values of MediaColumns.DATA and MediaColumns.RELATIVE_PATH columns might be malformed
+    private static boolean validateDirEntryName(String n) {
+        return n.length() != 0
+                && n.indexOf('/') < 0
+                && n.indexOf('\0') < 0;
+    }
+
+    private static void maybeAddDirEntry(String dirEntry, ArraySet<String> dirEntries, ArrayList<String> dest) {
+        if (!validateDirEntryName(dirEntry)) {
+            Log.e(TAG, "invalid dirEntry name" + dirEntry);
+            return;
+        }
+
+        if (dirEntries.add(dirEntry)) {
+            dest.add(dirEntry);
+        } // else dir entry was already present
+    }
+
+    @Nullable
+    private static String maybeExtractChildDirNameFromRelativePaths(String parentPath, String childPath) {
+        int adjustedParentLen = parentPath.length();
+        if (adjustedParentLen == 1) {
+            // relative path of the volume root is "/" instead of "", which is inconsistent with all
+            // other relative paths (eg "Android/", not "/Android/")
+
+            if (!parentPath.equals("/")) {
+                Log.e(TAG, "unexpected parentPath " + parentPath);
+                return null;
+            }
+            adjustedParentLen = 0;
+        }
+
+        int childLen = childPath.length();
+
+        int minChildLen = adjustedParentLen + 2; // two extra characters: '/' and a single-letter file name
+
+        if (childLen < minChildLen) {
+            if (childLen != parentPath.length()) {
+                Log.w(TAG, "inconsistent relative path " + childPath);
+            }
+            return null;
+        }
+
+        int dirNameStart = adjustedParentLen;
+        int dirNameEnd = childPath.indexOf('/', dirNameStart);
+
+        if (dirNameEnd <= dirNameStart) {
+            Log.w(TAG, "dirNameEnd not found, childPath: " + childPath);
+            return null;
+        }
+
+        return childPath.substring(dirNameStart, dirNameEnd);
+    }
+
+    private static void maybeExtractChildNameFromStorageScope(
+            String dirPath, StorageScope scope, ArraySet<String> dirEntries,
+            ArrayList<String> dirNames, ArrayList<String> fileNames)
+    {
+        final String scopePath = scope.path;
+
+        final int dirPathLen = dirPath.length();
+        final int minScopePathLen = dirPathLen + 2; // two characters: '/' and a single-letter dir entry name
+
+        if (scopePath.length() < minScopePathLen) {
+            return;
+        }
+
+        if (!scopePath.startsWith(dirPath)) {
+            return;
+        }
+
+        if (scopePath.charAt(dirPathLen) != '/') {
+            return;
+        }
+
+        final int nameStart = dirPathLen + 1;
+        int nameEnd = scopePath.indexOf('/', nameStart);
+
+        boolean fullPath = false;
+        if (nameEnd < 0) {
+            nameEnd = scopePath.length();
+            fullPath = true;
+        }
+
+        final String name = scopePath.substring(nameStart, nameEnd);
+
+        if (fullPath) {
+            File scopeFile = new File(scopePath);
+
+            if (scope.isDirectory()) {
+                if (scopeFile.isDirectory()) {
+                    maybeAddDirEntry(name, dirEntries, dirNames);
+                }
+            } else if (scope.isFile()) {
+                if (scopeFile.isFile()) {
+                    maybeAddDirEntry(name, dirEntries, fileNames);
+                }
+            }
+        } else {
+            File child = new File(scopePath.substring(0, nameEnd));
+            if (child.isDirectory()) {
+                maybeAddDirEntry(name, dirEntries, dirNames);
+            }
+        }
+    }
+}


### PR DESCRIPTION
For compatibility with legacy use-cases, access to custom alarm/notification/ringtone sounds was
allowed without any permission in commit ec2508f over 4 years ago.

Apps are supposed to access these files through RingtoneManager APIs (it supports alarm and
notification sounds too), which continue to work after this change, since the actual access to sound
files is performed by the OS, not by the app. These APIs cover both sound selection and playback.

Note that access was granted not only to audio files in Alarms/, Notifications/, Ringtones/ dirs in
root of shared storage, but to audio files in any dir in shared storage that has one of these names,
ie audio files in CustomMusicFolder/Album/Alarms dir were accessible without any permission too.

The most likely reason for this behavior is bug-for-bug compatibility with the original MediaScanner
which was first published in the initial AOSP source drop in 2008.

Code from 2008:
https://github.com/aosp-mirror/platform_frameworks_base/blob/54b6cfa9a9e5b861a9930af873580d6dc20f773c/media/java/android/media/MediaScanner.java#L455
Commit that introduced modern MediaScanner in 2019:
aosp-mirror/platform_packages_providers_mediaprovider@10b4d8d
Code from ModernMediaScanner:
https://github.com/aosp-mirror/platform_packages_providers_mediaprovider/blob/10b4d8df5dc06ee7f2d1bb5c5cc9638df43eea7e/src/com/android/providers/media/scan/ModernMediaScanner.java#L423

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2258