### PR TITLE
fixup! FuseDaemon: treat paths with ignorable code point as inaccessible

### DIFF
--- a/src/com/android/providers/media/util/FileUtils.java
+++ b/src/com/android/providers/media/util/FileUtils.java
@@ -1871,6 +1871,10 @@ public class FileUtils {
             if (android.icu.lang.UCharacter.hasBinaryProperty(codePoint, propToIgnore)) {
                 return true;
             }
+            int charCount = Character.charCount(codePoint);
+            if (charCount > 1) {
+                i += charCount - 1;
+            }
         }
         return false;
     }

--- a/tests/src/com/android/providers/media/util/FileUtilsTest.java
+++ b/tests/src/com/android/providers/media/util/FileUtilsTest.java
@@ -1364,4 +1364,28 @@ public class FileUtilsTest {
             }
         }
     }
+
+    @Test
+    public void testPathHasIgnorableCodePoint() {
+        {
+            String path = "/storage/emulated/0/Ringtones/a.mp3";
+            assertWithMessage("Expected has no ignorable code point for " + path)
+                    .that(FileUtils.hasIgnorableCodePointCharsOnPath(path)).isFalse();
+        }
+        {
+            String path = "/storage/emulated/0/Ringtones\u200B/a.mp3";
+            assertWithMessage("Expected has ignorable code point for " + path)
+                    .that(FileUtils.hasIgnorableCodePointCharsOnPath(path)).isTrue();
+        }
+        {
+            String path = "/storage/emulated/0/Ringtones/\u200Ba.mp3";
+            assertWithMessage("Expected has ignorable code point for " + path)
+                    .that(FileUtils.hasIgnorableCodePointCharsOnPath(path)).isTrue();
+        }
+        {
+            String path = "/storage/emulated/0/\u200BRingtones/\u200Ba.mp3";
+            assertWithMessage("Expected has ignorable code point for " + path)
+                    .that(FileUtils.hasIgnorableCodePointCharsOnPath(path)).isTrue();
+        }
+    }
 }


### PR DESCRIPTION
Improve correctness on iterating over codepoints on checking for ignorable codepoints.